### PR TITLE
Fix gallery ratios and animations

### DIFF
--- a/src/gallery/gallery_image.rs
+++ b/src/gallery/gallery_image.rs
@@ -36,7 +36,7 @@ live_design! {
                 off = {
                     from: {
                         ease: OutExp,
-                        all: Forward {duration: 0.3}
+                        all: Forward {duration: 0.4}
                     }
                     apply: {
                         image: {draw_bg: {scale: 0.0}}
@@ -45,7 +45,7 @@ live_design! {
                 on = {
                     from: {
                         ease: OutExp,
-                        all: Forward {duration: 0.3}
+                        all: Forward {duration: 0.4}
                     }
                     apply: {
                         image: { draw_bg: {scale: 1.0} }

--- a/src/gallery/gallery_image.rs
+++ b/src/gallery/gallery_image.rs
@@ -20,21 +20,22 @@ live_design! {
                         self.rect_size.y - 2.0,
                         max(1.0, self.radius)
                     )
-                    let max_scale = vec2(1.1);
+                    let max_scale = vec2(0.9);
                     let scale = mix(vec2(1.0), max_scale, self.scale);
                     let pan = mix(vec2(0.0), (vec2(1.0) - max_scale) * 0.5, self.scale);
-                    let color = self.get_color_scale_pan(scale, pan) + mix(vec4(0.0), vec4(0.1), self.down);
+
+                    let color = self.get_color_scale_pan(scale, pan) + mix(vec4(0.0), vec4(0.1), 0);
                     sdf.fill_keep(color);
                     return sdf.result
                 }
             }
         }
-
         animator: {
             zoom = {
                 default: off
                 off = {
                     from: {
+                        ease: OutExp,
                         all: Forward {duration: 0.3}
                     }
                     apply: {
@@ -43,6 +44,7 @@ live_design! {
                 }
                 on = {
                     from: {
+                        ease: OutExp,
                         all: Forward {duration: 0.3}
                     }
                     apply: {

--- a/src/gallery/gallery_image.rs
+++ b/src/gallery/gallery_image.rs
@@ -6,6 +6,7 @@ live_design! {
     import makepad_draw::shader::std::*;
 
     GalleryImage = {{GalleryImage}} {
+        align: {x: 0.5, y: 0.5}
         image: <Image> {
             draw_bg: {
                 instance radius: 3.
@@ -98,7 +99,7 @@ impl GalleryImage {
         self.path = path;
     }
 
-    pub fn set_size(&mut self, size: DVec2) {
+    pub fn set_size(&mut self, cx: &mut Cx, size: DVec2) {
         self.size = size;
     }
 

--- a/src/gallery/gallery_image.rs
+++ b/src/gallery/gallery_image.rs
@@ -37,7 +37,7 @@ live_design! {
                 off = {
                     from: {
                         ease: OutExp,
-                        all: Forward {duration: 0.5}
+                        all: Forward {duration: 0.4}
                     }
                     apply: {
                         image: {draw_bg: {scale: 0.0}}
@@ -46,7 +46,7 @@ live_design! {
                 on = {
                     from: {
                         ease: OutExp,
-                        all: Forward {duration: 0.5}
+                        all: Forward {duration: 0.4}
                     }
                     apply: {
                         image: { draw_bg: {scale: 1.0} }

--- a/src/gallery/gallery_image.rs
+++ b/src/gallery/gallery_image.rs
@@ -37,7 +37,7 @@ live_design! {
                 off = {
                     from: {
                         ease: OutExp,
-                        all: Forward {duration: 0.4}
+                        all: Forward {duration: 0.5}
                     }
                     apply: {
                         image: {draw_bg: {scale: 0.0}}
@@ -46,7 +46,7 @@ live_design! {
                 on = {
                     from: {
                         ease: OutExp,
-                        all: Forward {duration: 0.4}
+                        all: Forward {duration: 0.5}
                     }
                     apply: {
                         image: { draw_bg: {scale: 1.0} }

--- a/src/gallery/gallery_image_slider.rs
+++ b/src/gallery/gallery_image_slider.rs
@@ -260,15 +260,15 @@ impl GalleryImageSlider {
                     // self.last_swipe_direction = if self.swipe_vector_x > 0. { 1. } else { -1. };
 
                     let mut new_index = self.current_index;
-
-                    if self.swipe_vector_x.abs() > swipe_trigger_value {
-                        new_index += if self.swipe_vector_x > 0. { -1 } else { 1 };
-                        self.offset = self.swipe_vector_x.abs();
-                    }
                     // Handle prohibited swipe cases
                     // keep the index in range
                     if new_index < 0 || new_index > self.image_count - 1 {
                         return;
+                    }
+
+                    if self.swipe_vector_x.abs() > swipe_trigger_value {
+                        new_index += if self.swipe_vector_x > 0. { -1 } else { 1 };
+                        self.offset = self.swipe_vector_x.abs();
                     }
 
                     self.set_index(new_index, cx);

--- a/src/gallery/gallery_image_slider.rs
+++ b/src/gallery/gallery_image_slider.rs
@@ -14,7 +14,7 @@ live_design! {
 
     GalleryImageSlider = {{GalleryImageSlider}} {
         width: Fill, height: Fill
-
+        align: {y: 0.5}
         images_deps: [
             dep("crate://self/resources/images/gallery/great-wall/gallery-great-wall-0.jpg"),
             dep("crate://self/resources/images/gallery/great-wall/gallery-great-wall-1.jpg"),
@@ -46,6 +46,7 @@ live_design! {
 
         gallery_image_template: <GalleryImage> {
             image: {
+                fit: Horizontal,
                 draw_bg: {
                     instance radius: 0.
                 }
@@ -171,7 +172,7 @@ impl Widget for GalleryImageSlider {
             let mut pos = start_pos
                 + dvec2(
                     (image_idu64 as f64 * padded_image_width + image_offset.x) - image_width / 2.,
-                    -(image_height / 2.) + 20.,
+                    -(image_height / 2.) - 60.,
                 );
 
             if let Some(image_path) = match image_idu64 {

--- a/src/gallery/gallery_image_slider.rs
+++ b/src/gallery/gallery_image_slider.rs
@@ -172,7 +172,7 @@ impl Widget for GalleryImageSlider {
             let mut pos = start_pos
                 + dvec2(
                     (image_idu64 as f64 * padded_image_width + image_offset.x) - image_width / 2.,
-                    -(image_height / 2.) - 60.,
+                    -(image_height / 2.) - 80.,
                 );
 
             if let Some(image_path) = match image_idu64 {

--- a/src/gallery/gallery_image_slider.rs
+++ b/src/gallery/gallery_image_slider.rs
@@ -180,7 +180,7 @@ impl Widget for GalleryImageSlider {
                 _ => Some(self.images_deps[image_idu64 as usize].as_str()),
             } {
                 gallery_image.set_path(image_path.to_owned());
-                gallery_image.set_size(dvec2(image_width, image_height));
+                gallery_image.set_size(cx, dvec2(image_width, image_height));
             }
 
             gallery_image.draw_all(cx, &mut Scope::with_data(&mut pos));

--- a/src/gallery/gallery_overlay.rs
+++ b/src/gallery/gallery_overlay.rs
@@ -63,13 +63,13 @@ live_design! {
             shrink_vertically = {
                 default: off
                 on = {
-                    from: {all: Forward {duration: 0.075}}
+                    from: {all: Forward {duration: 0.15}}
                     apply: {
                         draw_bg: {crop_height: 320}
                     }
                 }
                 off = {
-                    from: {all: Forward {duration: 0.075}}
+                    from: {all: Forward {duration: 0.15}}
                     apply: {
                         draw_bg: {crop_height: 430}
                     }

--- a/src/gallery/gallery_screen.rs
+++ b/src/gallery/gallery_screen.rs
@@ -49,7 +49,35 @@ live_design! {
             dep("crate://self/resources/images/gallery/great-wall/gallery-great-wall-23.jpg"),
         ]
 
-        gallery_image_template: <GalleryImage> {}
+        gallery_image_template: <GalleryImage> {
+            image: <Image> {
+                fit: Biggest
+                draw_bg: {
+                    instance radius: 3.
+                    instance scale: 0.0
+                    instance down: 0.0
+                    instance size: vec2(270., 430.)
+
+                    fn pixel(self) -> vec4 {
+                        let sdf = Sdf2d::viewport(self.pos * self.rect_size);
+                        sdf.box(
+                            1,
+                            1,
+                            self.size.x - 2.0,
+                            self.size.y - 2.0,
+                            max(1.0, self.radius)
+                        )
+                        let max_scale = vec2(0.9);
+                        let scale = mix(vec2(1.0), max_scale, self.scale);
+                        let pan = mix(vec2(0.0), (vec2(1.0) - max_scale) * 0.5, self.scale);
+
+                        let color = self.get_color_scale_pan(scale, pan) + mix(vec4(0.0), vec4(0.1), 0);
+                        sdf.fill_keep(color);
+                        return sdf.result
+                    }
+                }
+            }
+        }
 
         // This values are hardcoded from the width and height of the image
         image_offset: vec2(290., 450.)
@@ -205,7 +233,7 @@ impl Widget for Gallery {
                 _ => Some(self.images_deps[image_idu64 as usize].as_str()),
             } {
                 gallery_image.set_path(image_path.to_owned());
-                gallery_image.set_size(dvec2(IMAGE_WIDTH, IMAGE_HEIGHT));
+                gallery_image.set_size(cx, dvec2(IMAGE_WIDTH, IMAGE_HEIGHT));
             }
 
             gallery_image.draw_all(cx, &mut Scope::with_data(&mut pos));

--- a/src/gallery/gallery_screen.rs
+++ b/src/gallery/gallery_screen.rs
@@ -79,33 +79,32 @@ live_design! {
             }
         }
 
-        // This values are hardcoded from the width and height of the image
-        image_offset: vec2(290., 450.)
+        swipe_progress: vec2(1., 1.)
 
         animator: {
             swipe = {
                 default: idle,
                 idle = {
                     from: {all: Snap}
-                    apply: {image_offset: vec2(0., 0.)}
+                    apply: {swipe_progress: vec2(0., 0.)}
                 }
 
                 horizontal = {
                     from: {all: Forward {duration: 0.15}}
-                    apply: {image_offset: vec2(290., 0.)}
+                    apply: {swipe_progress: vec2(1., 0.)}
                 }
                 vertical = {
                     from: {all: Forward {duration: 0.15}}
-                    apply: {image_offset: vec2(0., 450.)}
+                    apply: {swipe_progress: vec2(0., 1.)}
                 }
                 diagonal = {
                     from: {all: Forward {duration: 0.15}}
-                    apply: {image_offset: vec2(290., 450.)}
+                    apply: {swipe_progress: vec2(1., 1.)}
                 }
 
                 reset = {
                     from: {all: Snap}
-                    apply: {image_offset: vec2(0., 0.)}
+                    apply: {swipe_progress: vec2(0., 0.)}
                 }
             }
         }
@@ -145,7 +144,7 @@ pub struct Gallery {
     #[redraw]
     area: Area,
     #[live]
-    image_offset: DVec2,
+    swipe_progress: DVec2,
 
     #[rust]
     images: ComponentMap<GalleryImageId, GalleryImage>,
@@ -261,9 +260,6 @@ impl Gallery {
             -(IMAGE_HEIGHT + IMAGE_PADDING) * previous_row,
         );
 
-        let padded_size = dvec2(IMAGE_WIDTH + IMAGE_PADDING, IMAGE_HEIGHT + IMAGE_PADDING);
-
-        let progress = self.image_offset / padded_size;
         // Check if the animation is complete
         if !self.animator.is_track_animating(cx, id!(swipe)) {
             if self.animator.animator_in_state(cx, id!(swipe.vertical))
@@ -277,8 +273,8 @@ impl Gallery {
 
         // Interpolate between the previous and current offsets
         let interpolated_offset = dvec2(
-            previous_offset.x + (current_offset.x - previous_offset.x) * progress.x,
-            previous_offset.y + (current_offset.y - previous_offset.y) * progress.y,
+            previous_offset.x + (current_offset.x - previous_offset.x) * self.swipe_progress.x,
+            previous_offset.y + (current_offset.y - previous_offset.y) * self.swipe_progress.y,
         );
 
         interpolated_offset

--- a/src/gallery/gallery_screen.rs
+++ b/src/gallery/gallery_screen.rs
@@ -161,6 +161,9 @@ impl LiveHook for Gallery {
 
 impl Widget for Gallery {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        for image in self.images.values_mut() {
+            image.handle_event(cx, event, scope);
+        }
         self.view.handle_event(cx, event, scope);
         if self.animator_handle_event(cx, event).is_animating() {
             self.redraw(cx);

--- a/src/gallery/gallery_screen.rs
+++ b/src/gallery/gallery_screen.rs
@@ -81,8 +81,6 @@ live_design! {
                 }
             }
         }
-
-
     }
 
     GalleryScreen = <View> {
@@ -356,7 +354,9 @@ impl Gallery {
                     cx.widget_action(
                         widget_uid,
                         &scope.path,
-                        StackNavigationAction::NavigateTo(live_id!(gallery_image_slider_stack_view))
+                        StackNavigationAction::NavigateTo(live_id!(
+                            gallery_image_slider_stack_view
+                        )),
                     );
                 }
                 // Reset variable for swiping


### PR DESCRIPTION
Fixes:
- Grid images ratios
- Grid zoom animation
- Slider images ratios
- Keeps the slider from swiping out of bounds

Also makes a cleanup of the gallery screen animation code and changes small values, like margins and animation durations.