### PR TITLE
build: add osiris metadata/entrypoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,20 @@ edition = "2021"
 
 [dependencies]
 makepad-widgets = { path = "../makepad/widgets", version = "0.6.0" }
+
+[package.metadata]
+osiris.application.id = "Wonderous"
+
+[[package.metadata.osiris.platforms]]
+id = "macos"
+macos.abis = ["native"]
+#macos.bundle-id = "rs.robius.wonderous"
+#macos.version-code = 1
+#macos.version-name = "0.1.0"
+
+[[package.metadata.osiris.archives]]
+id = "macos-pkg"
+macos-pkg.app-id = "TBD.rs.robius.wonderous"
+#macos-pkg.codesign-identity = "./TBD"
+#macos-pkg.pkgsign-identity = "./TBD"
+#macos-pkg.provision-file = "./TBD"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,8 @@ mod gallery;
 mod shared;
 mod timeline;
 mod wonder;
+
+#[allow(dead_code)]
+fn main() {
+    app::app_main()
+}


### PR DESCRIPTION
Add enough metadata to allow building macOS bundles via cargo-osiris. This adds:

 - Library entrypoint as replacement for `src/main.rs`
 - Generic Osiris metadata that defines the application ID, so the produced bundle uses `Wonderous.app`, rather than `makepad_wonderous.app`.
 - macOS platform metadata, so the app is only compiled for the native architecture (cross-arch builds are broken in makepad upstream).
 - macOS archive metadata, so the app archives use a proper Apple AppID.

If `cargo-osiris` is available in PATH, you can now use:

    cargo-osiris build --platform macos
    cargo-osiris archive --platform macos --archive macos-pkg

This will produce:

    ./target/osiris/platform/macos/Wonderous.app/
    ./target/osiris/platform/macos/Wonderous.pkg

The `pkg` product can be submitted to TestFlight and should pass all verification, if a registered Apple AppID is used, as well as an macOS Distribution certificate with related provisioning-profile is used.

Note that `cargo-osiris` has no release on crates.io so far. I will gladly provide one, if there is interest in it. Furthermore, note that several keys in `Cargo.toml` are commented out, since they require paths or identities to be acquired from the apple developer website. These ultimately will have to move out of `Cargo.toml`, since they are local configuration rather than project-wide metadata. However, there is no clear agreement on where to put those, so I have left them in.

Cc: @guofoo 