### PR TITLE
Use fixed sizes for grid images

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -363,7 +363,7 @@ impl MatchEvent for App {
             self.ui.redraw(cx);
         }
 
-        // FIXME: Ideally this would be within the ArtifactsScreen,
+        // TODO: Ideally this would be within the ArtifactsScreen,
         // however making ArtifactsScreen into a Widget instead of a simple View,
         // breaks the stack navigation layout for some reason
         if self


### PR DESCRIPTION
Currently the image "boxes" (`ImageGrid`) are set to Fit the height of the images. This causes some minor visual artifacts when scrolling fast, since the container first has a predetermined size showing a spinner, which later resizes to the actual image content.

These changes mimic more closely the flutter implementation, where the image "boxes" have fixed predetermined sizes, and then the actual images are adjusted to fit the content covering the available space.